### PR TITLE
내부 property구성에 방법으로 dom-repeat추가

### DIFF
--- a/demo/index-scene-properties.html
+++ b/demo/index-scene-properties.html
@@ -19,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../things-scene-viewer/things-scene-layer.html">
     <link rel="import" href="../../things-scene-viewer/things-scene-handler.html">
 
-    <link rel="import" href="../../things-designer-elements/things-designer-elements.html">
+    <link rel="import" href="../../things-designer-elements/elements.html">
     <link rel="import" href="../../things-scene-viewer/things-scene-viewer.html">
 
     <link rel="import" href="../things-scene-properties.html">
@@ -48,14 +48,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <things-scene-handler type="move-handler"></things-scene-handler>
       </things-scene-viewer>
 
-      <things-scene-properties scene="[[scene]]"
+      <things-scene-properties id="properties"
+                               scene="[[scene]]"
                                selected="[[selected]]"
                                model="{{target}}"
-                               bounds="{{bounds}}">
-        <label>Center X</label>
-        <input type="number" value-as-number="{{target.cx::change}}">
-        <label>Width</label>
-        <input type="number" value-as-number="{{bounds.width::change}}">
+                               bounds="{{bounds}}"
+                               props="{{props}}">
       </things-scene-properties>
 
     </template>
@@ -80,10 +78,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             value: 75,
             alpha: 0.8,
             text: "#{value}%"
-          }]             
-        }        
+          }]
+        }
+
+        var propEditors = [{
+          type: 'number',
+          label: 'Center X',
+          name: 'cx'
+        }, {
+          type: 'number',
+          label: 'Center Y',
+          name: 'cy'
+        }, {
+          type: 'number',
+          label: 'Radius X',
+          name: 'rx'
+        }, {
+          type: 'number',
+          label: 'Radius Y',
+          name: 'ry'
+        }, {
+          type: 'number',
+          label: 'Line Width',
+          name: 'lineWidth'
+        }, {
+          type: 'number',
+          label: 'Font Size',
+          name: 'fontSize'
+        }, {
+          type: 'number',
+          label: 'Top',
+          name: 'top'
+        }, {
+          type: 'color',
+          label: 'Stroke Style',
+          name: 'strokeStyle'
+        }, {
+          type: 'color',
+          label: 'Font Color',
+          name: 'fontColor'
+        }, {
+          type: 'number',
+          label: 'Alpha',
+          name: 'alpha',
+          property: 'number'
+        }, {
+          type: 'number',
+          label: 'Value',
+          name: 'value',
+          property: 'number'
+        }]
 
         app.model = model
+        app.props = propEditors
+
+
+        app.$.properties.addEventListener('change', function(e) {
+          console.log('change', e, app.$.properties.model)
+        })
       });
     </script>
 

--- a/things-scene-properties.html
+++ b/things-scene-properties.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
+<link rel="import" href="../things-designer-elements/things-editor-property.html">
 <!--
 An element providing a solution to no problem in particular.
 
@@ -47,6 +48,14 @@ Example:
 
     <content></content>
 
+    <template is="dom-repeat" items="[[props]]">
+      <things-editor-property label="[[item.label]]"
+                              type="[[item.type]]"
+                              name$="[[item.name]]"
+                              property="[[item.property]]">
+      </things-editor-property>
+    </template>
+
   </template>
 
   <script>
@@ -76,7 +85,9 @@ Example:
         model: {
           type: Object,
           notify: true
-        }
+        },
+
+        props: Array
       },
 
       observers: [
@@ -84,6 +95,10 @@ Example:
         '_onModelChanged(model.*)',
         '_onBoundsChanged(bounds.*)'
       ],
+
+      listeners: {
+        'change': '_onValueChanged'
+      },
 
       _defaultPropertyTarget: function() {
         if(!this.scene) {
@@ -98,14 +113,50 @@ Example:
         }
       },
 
+      _setValue: function(name) {
+        var prop = this.querySelector('things-editor-property[name=' + name + ']')
+        if(!prop)
+          return
+
+        prop.value = this.model[name]
+      },
+
+      _setValues: function() {
+        var self = this
+        Array.from(this.querySelectorAll('things-editor-property')).forEach(function(prop) {
+          var name = prop.getAttribute('name')
+          prop.value = self.model[name]
+        })
+      },
+
+      _onValueChanged: function(e) {
+        var prop = e.target
+        while(prop && prop.tagName != 'THINGS-EDITOR-PROPERTY')
+          prop = prop.parentNode
+
+        if(!prop || prop.tagName != 'THINGS-EDITOR-PROPERTY')
+          return
+
+        var name = prop.getAttribute('name')
+
+        this._changedOnThis = true
+        this.set('model.' + name, prop.value)
+        this._changedOnThis = false
+      },
+
       _onSceneChanged: function() {
         this._defaultPropertyTarget()
       },
 
       _onModelChanged: function(change) {
 
+        if(change.path === 'model'){
+          this._setValues()
+          return
+        }
+
         /* 사용자가 선택한 컴포넌트가 바뀐 경우도 호출되므로, 이 경우는 제외한다. */
-        if(change.path === 'model' || this.changedByScene)
+        if(this.changedByScene)
           return
 
         var self = this
@@ -203,8 +254,6 @@ Example:
           after.on('change', this._onModelChangedB, this)
         }
       }
-
     })
   </script>
 </dom-module>
-


### PR DESCRIPTION
things-scene-properties.html
- dom-repeat으로 props로 넘겨받은 속성에 맞는 property를 화면에 추가한다.

demo/index-scene-properties.html
- 해당 변경사항에 맞도록 데모 수정
